### PR TITLE
fix: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-on-version-change.yml
+++ b/.github/workflows/publish-on-version-change.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [assigned, opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/secrets-scan.yaml
+++ b/.github/workflows/secrets-scan.yaml
@@ -9,6 +9,10 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   secrets-scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/fylein/fyle-integrations-platform-connector/security/code-scanning/4](https://github.com/fylein/fyle-integrations-platform-connector/security/code-scanning/4)

Add an explicit `permissions` block to `.github/workflows/pylint.yml` at the workflow root (top-level), so it applies to all jobs unless overridden. For this workflow, `contents: read` is sufficient because it checks out code and runs linting only, with no writes needed. This is the minimal, least-privilege fix and does not change functional behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

Clickup
app.clickup.com
