### PR TITLE
fix: sync paid by company expenses

### DIFF
--- a/connector/fyle_integrations_platform_connector/apis/expenses.py
+++ b/connector/fyle_integrations_platform_connector/apis/expenses.py
@@ -34,7 +34,7 @@ class Expenses(Base):
         generator = self.connection.list_all(query_params)
 
         for expense_list in generator:
-            expenses = self.__filter_personal_expenses(expense_list)
+            expenses = expense_list['data']
             if filter_credit_expenses:
                 expenses = self.__filter_credit_expenses(expenses)
             all_expenses.extend(expenses)
@@ -105,23 +105,6 @@ class Expenses(Base):
             query_params['id'] = 'eq.{}'.format(expense_id)
 
         return query_params
-
-
-    @staticmethod
-    def __filter_personal_expenses(expense_list: dict) -> List[dict]:
-        """
-        Filter personal expenses.
-        :param expense_list: Expense list.
-        :return: Expense list.
-        """
-        return list(
-            filter(
-                lambda expense: not (
-                    not expense['is_reimbursable'] and expense['source_account']['type'] == 'PERSONAL_CASH_ACCOUNT'
-                ),
-                expense_list['data']
-            )
-        )
 
 
     @staticmethod

--- a/connector/setup.py
+++ b/connector/setup.py
@@ -5,7 +5,7 @@ with open('../README.md', 'r', encoding='utf-8') as f:
 
 setuptools.setup(
     name='fyle-integrations-platform-connector',
-    version='3.0.1',
+    version='3.0.2',
     author='Shwetabh Kumar',
     author_email='shwetabh.kumar@fyle.in',
     description='A common platform connector for all the Fyle Integrations to interact with Fyle Platform APIs',


### PR DESCRIPTION
https://app.clickup.com/ 


This pull request primarily refactors the way expenses are filtered and retrieved in the `expenses.py` API, simplifying the logic and removing an unnecessary filtering step. It also includes a minor version bump for the package.

Expense filtering and retrieval logic:

* Removed the `__filter_personal_expenses` method and its usage, so expenses are now taken directly from the `'data'` field of the API response without additional filtering for personal expenses. (`connector/fyle_integrations_platform_connector/apis/expenses.py`) [[1]](diffhunk://#diff-8b47d81ff390bfe455a33d7e3b2b6fd19f31200012cd72314b53e14710ce2193L37-R37) [[2]](diffhunk://#diff-8b47d81ff390bfe455a33d7e3b2b6fd19f31200012cd72314b53e14710ce2193L110-L126)
* Adjusted the main expense retrieval method to directly use `expense_list['data']`, streamlining the data flow. (`connector/fyle_integrations_platform_connector/apis/expenses.py`)

Version update:

* Bumped the package version from `3.0.1` to `3.0.2` to reflect these changes. (`connector/setup.py`)